### PR TITLE
Replace image and IPs from stock docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.3.1
+    image: arnaus/mastodon:vanilla_rpi5_4.3.1
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -70,7 +70,7 @@ services:
       # prettier-ignore
       test: ['CMD-SHELL',"curl -s --noproxy localhost localhost:3000/health | grep -q 'OK' || exit 1"]
     ports:
-      - '127.0.0.1:3000:3000'
+      - '0.0.0.0:3000:3000'
     depends_on:
       - db
       - redis
@@ -83,7 +83,7 @@ services:
     # build:
     #   dockerfile: ./streaming/Dockerfile
     #   context: .
-    image: ghcr.io/mastodon/mastodon-streaming:v4.3.1
+    image: arnaus/mastodon:vanilla-streaming_rpi5_4.3.1
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -94,14 +94,14 @@ services:
       # prettier-ignore
       test: ['CMD-SHELL', "curl -s --noproxy localhost localhost:4000/api/v1/streaming/health | grep -q 'OK' || exit 1"]
     ports:
-      - '127.0.0.1:4000:4000'
+      - '0.0.0.0:4000:4000'
     depends_on:
       - db
       - redis
 
   sidekiq:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.3.1
+    image: arnaus/mastodon:vanilla_rpi5_4.3.1
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq


### PR DESCRIPTION
Modify the stock `docker-compose.yml` file so that:
- It uses the custom vanilla RPi5 built images
- It allows incoming traffic from any IP (The traffic comes from an external Reverse Proxy)